### PR TITLE
fix: handle empty `display_name`

### DIFF
--- a/src/generateMastodonEmbed.ts
+++ b/src/generateMastodonEmbed.ts
@@ -33,6 +33,7 @@ export const generateMastodonEmbed = async ({
 
     return embedData;
   } catch (error) {
+    console.error("Error fetching Mastodon post", error);
     return null;
   }
 };

--- a/src/utils/convertors.ts
+++ b/src/utils/convertors.ts
@@ -15,10 +15,10 @@ export const convertResponseToData = (
     !response.account ||
     !response.account.url ||
     !response.account.username ||
-    !response.account.display_name ||
     !response.account.avatar ||
     !response.created_at
   ) {
+    console.error("Invalid Mastodon response", response);
     return null;
   }
 
@@ -34,7 +34,13 @@ export const convertResponseToData = (
     card,
     emojis,
   } = response;
-  const { url: accountUrl, username, display_name, avatar } = account;
+  const { url: accountUrl, username, avatar } = account;
+
+  // NOTE: sometimes instances return empty display_name, so we use the username as a fallback
+  let display_name = account.display_name;
+  if (!account.display_name) {
+    display_name = username;
+  }
 
   return {
     content,

--- a/src/utils/demoPosts.ts
+++ b/src/utils/demoPosts.ts
@@ -8,4 +8,5 @@ export const demoPosts = [
   "@thisismissem@hachyderm.io:112022457133862143", // with embedded github card
   "@rosnovsky@lounge.town:111943084834223099", // with embedded youtube card
   "@DrOinFLA@lounge.town:111605128127230772", // with custom emoji
+  "@AsyncX@mastodon.social:112054527697723909", // Issue #25, emplty display_name returned by mastodon.social
 ];


### PR DESCRIPTION
Sometimes instances return an empty `display_name` field. This PR introduces a fallback to `username` in such cases.

Closes #25 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new demo post to improve the representation of edge cases in the UI.
- **Bug Fixes**
	- Enhanced error handling when fetching Mastodon posts.
	- Updated data conversion logic to handle cases with empty `display_name`, ensuring a fallback to `username`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->